### PR TITLE
[LF35] Implement Fridge Item Action Buttons

### DIFF
--- a/lib/wtfridge/handler/fridge_handler.dart
+++ b/lib/wtfridge/handler/fridge_handler.dart
@@ -66,10 +66,12 @@ Future<void> pushToDB(Client client, FridgeItem i) async {
     }
   }
 
-  updateItem(IOClient client, Map<String, dynamic> newValues) async {
-    newValues["new_date"] = DateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format((newValues["new_date"] as DateTime).toUtc());
-    String body = json.encode(newValues);
+  updateItem(Client client, Map<String, dynamic> newValues) async {
+    if (newValues.containsKey("new_date")) {
+      newValues["new_date"] = DateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format((newValues["new_date"] as DateTime).toUtc());
+    }
 
+    String body = json.encode(newValues);
     var response = await client.put(url, body: body);
     if (response.statusCode != 200) {
       throw ClientException("Failed to update item: ${response.body}");

--- a/lib/wtfridge/view/fridge_view.dart
+++ b/lib/wtfridge/view/fridge_view.dart
@@ -51,7 +51,8 @@ class _FridgeViewState extends ConsumerState<FridgeView> {
                         FridgeItemCard currentCard = fridgeCards.elementAt(i);
                         return currentCard;
                     }).toList(),
-                            ),
+                  ),
+                  const SizedBox(height: 50.0)
                 ],
               ),
             )],


### PR DESCRIPTION
- Adds delete functionality to reduce the quantity of an item by one when eaten\wasted is tapped, or fully deleted when either is held.
- Adds animation to quantity when it is reduced.
- Makes it so only a single fridge item card can be opened at a time.